### PR TITLE
Remove sentence about labels since no longer using labels

### DIFF
--- a/similart/templates/results.html.jinja
+++ b/similart/templates/results.html.jinja
@@ -3,7 +3,6 @@
   <div id="result-blurb">
     <p>
       Below is a graph representing the similarity connections between artworks based on the artwork you selected/uploaded.
-      The artist name is shown on the label above each node.
       Click on a node to see details of each recommended artwork.
       Enjoy!
     </p>


### PR DESCRIPTION
Since we changed the nodes to image previews, we no longer need the sentence in the description about the text labels above the circles so I removed that part.